### PR TITLE
商品一覧機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:index]
   def index
     @items = Item.order('created_at DESC')
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,9 +10,13 @@ class Item < ApplicationRecord
   end
 
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to :status, :category, :burden, :prefecture, :shipping_day
 
-  
+  belongs_to_active_hash :status
+  belongs_to_active_hash :category
+  belongs_to_active_hash :burden
+  belongs_to_active_hash :prefecture
+  belongs_to_active_hash :shipping_day
+
   with_options numericality: { other_than: 1 } do
     validates :status_id
     validates :burden_id

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -156,7 +156,7 @@
       </li>
 
       <%# 商品がない場合のダミー %>
-      <% if @item.present? %>
+      <% if @items.blank? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,25 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
+      <% @items.each do |item| %>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.burden.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,11 +152,11 @@
           </div>
         </div>
         <% end %>
+      <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @item.present? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,7 +174,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>


### PR DESCRIPTION
What
商品一覧表示機能を実装する。
Why
ユーザーから出品された商品をトップページに一覧表示させるため。

実装した機能
　ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
　出品した商品の一覧表示ができていること
　上から、出品された日時が新しい順に表示されること
　『画像/価格/商品名』の3つの情報について表示できていること
https://gyazo.com/9897ce561704b68471ab4cd77d9fcc70

コードレビューをお願いします。